### PR TITLE
Fix occurred dead lock

### DIFF
--- a/src/main/java/edu/rice/pcdp/runtime/BaseTask.java
+++ b/src/main/java/edu/rice/pcdp/runtime/BaseTask.java
@@ -84,6 +84,10 @@ public abstract class BaseTask extends CountedCompleter<Void> {
          */
         public void awaitCompletion() {
             try {
+                // Wait for end of computations registered on
+                // this finish scope.
+                // Moreover join allow us to handle exceptions
+                // while computing the runnable
                 join();
             } catch (final Exception ex) {
                 pushException(ex);

--- a/src/test/java/edu/rice/pcdp/finish/TestFinish9TooMoreFinish.java
+++ b/src/test/java/edu/rice/pcdp/finish/TestFinish9TooMoreFinish.java
@@ -1,0 +1,80 @@
+package edu.rice.pcdp.finish;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static edu.rice.pcdp.PCDP.async;
+import static edu.rice.pcdp.PCDP.finish;
+
+/**
+ * There are no  dead lock and blocked workers
+ * when execution task haves quantity of finish
+ * statements grater then quantity of workers.
+ *
+ * This test does not proof correct invocation
+ * in concurrency environment.
+ *
+ * @author BadPitt
+ */
+@RunWith(JUnit4.class)
+public class TestFinish9TooMoreFinish {
+
+    private static final int ARRAY_LENGTH = 10_000;
+    private static final int[] ARRAY = new int[ARRAY_LENGTH];
+
+    @BeforeClass
+    public static void setUp() {
+        for (int i = 0; i < ARRAY.length; i++) {
+            ARRAY[i] = i+1;
+        }
+    }
+
+    @Test
+    public void nestedFinishTest() {
+        final int dataLength = Runtime.getRuntime().availableProcessors() * 2;
+        final int[] parResult =  new int[1];
+
+        finish(() -> {
+            parResult[0] = sum(dataLength, 0, 0, ARRAY.length);
+        });
+        System.out.printf("Parallel result is: %d\n", parResult[0]);
+
+        int seqResult =  0;
+        for (int i = 0; i < ARRAY.length; i++) {
+            seqResult += ARRAY[i];
+        }
+        System.out.printf("Sequencial result is: %d", seqResult);
+    }
+
+    private int sum(final int dataLength,
+                    final int depth,
+                    final int left,
+                    final int right) {
+        // Base case
+        if (depth >= dataLength) {
+            int result =  0;
+            for (int i = left; i < right; i++) {
+                result += ARRAY[i];
+            }
+            return result;
+        }
+        // Normal case
+        // we don't need additional synchronization like atomic, volatile and etc.
+        final int[] finishResult = new int[]{0};
+        final int[] firstResult = new int[]{0};
+        final int[] secondResult = new int[]{0};
+        finish(() -> {
+            async(() -> {
+                firstResult[0] = sum(dataLength, depth + 1, left, (right+left)/2);
+            });
+            async(() -> {
+                secondResult[0] = sum(dataLength, depth + 1, (right+left)/2, right);
+            });
+        });
+        finishResult[0] = firstResult[0] + secondResult[0];
+
+        return finishResult[0];
+    }
+}

--- a/src/test/java/edu/rice/pcdp/finish/TestFinish9TooMoreFinish.java
+++ b/src/test/java/edu/rice/pcdp/finish/TestFinish9TooMoreFinish.java
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4;
 
 import static edu.rice.pcdp.PCDP.async;
 import static edu.rice.pcdp.PCDP.finish;
+import static org.junit.Assert.assertEquals;
 
 /**
  * There are no  dead lock and blocked workers
@@ -31,6 +32,29 @@ public class TestFinish9TooMoreFinish {
         }
     }
 
+    /**
+     * In this case we have recursive computation tree
+     * where each layer of recursion waiting for end of
+     * all async task in the layer.
+     *
+     * finish {
+     *      task{}
+     * }
+     *
+     * where task is:
+     *      finish {
+     *        \  \______
+     *        \__       async{task}
+     *            async{task}
+     *      }
+     *
+     * thus quantity of finish statements would be 2^n-1
+     * where n - is depth of recursion.
+     *
+     * If the sum of finish statements be greater then
+     * quantity of workers(by default = available processors)
+     * we will expect missing of dead lock.
+     */
     @Test
     public void nestedFinishTest() {
         final int dataLength = Runtime.getRuntime().availableProcessors() * 2;
@@ -46,6 +70,8 @@ public class TestFinish9TooMoreFinish {
             seqResult += ARRAY[i];
         }
         System.out.printf("Sequencial result is: %d", seqResult);
+
+        assertEquals(parResult[0], seqResult);
     }
 
     private int sum(final int dataLength,


### PR DESCRIPTION
Blocking approach has bean changed to the "join" invocations of CountedCompleater. That allows worker to find other task